### PR TITLE
Fix undefined current-line-contents

### DIFF
--- a/block-nav.el
+++ b/block-nav.el
@@ -6,7 +6,7 @@
   (back-to-indentation)
   (cond ((< original-column (current-column))
          (block-nav-move-block dir original-column))
-        ((string-empty-p (current-line-contents))
+        ((string-empty-p (buffer-substring (line-beginning-position) (line-end-position)))
          (block-nav-move-block dir original-column))
         (t (when block-nav-center-after-scroll
              (recenter)))))


### PR DESCRIPTION
`current-line-contents` function is undefined for me and I can't find it where it is defined. It may be defined on third-party package.

The solution comes from: https://emacs.stackexchange.com/questions/15134/how-to-get-contents-of-current-line