### PR TITLE
Skip shallower lines

### DIFF
--- a/block-nav.el
+++ b/block-nav.el
@@ -41,8 +41,13 @@
 ;;
 ;;; Code:
 
-(defvar block-nav-center-after-scroll nil)
-(defvar block-nav-move-skip-shallower nil)
+(defvar block-nav-center-after-scroll nil
+  "When not-nil, Emacs will recenter the current line after moving")
+(defvar block-nav-move-skip-shallower nil
+  "
+  When not-nil, calling `block-nav-next/previous-block` will 
+  skip over lines with a shallower indentation than the current line.
+  ")
 
 (defun block-nav-move-block (dir original-column)
   "

--- a/block-nav.el
+++ b/block-nav.el
@@ -58,8 +58,8 @@
 (defun test-end-of-space (dir)
   (or
    (and (> dir 0)
-        (= (count-lines (point-min) (point-max))
-           (line-number-at-pos)))
+        (<= (count-lines (point-min) (point-max))
+            (line-number-at-pos)))
    (and (< dir 0)
         (= 1 (line-number-at-pos)))))
 

--- a/block-nav.el
+++ b/block-nav.el
@@ -41,7 +41,8 @@
 ;;
 ;;; Code:
 
-(defvar block-nav-center-after-scroll t)
+(defvar block-nav-center-after-scroll nil)
+(defvar block-nav-move-skip-shallower nil)
 
 (defun block-nav-move-block (dir original-column)
   "
@@ -52,12 +53,21 @@
   (interactive)
   (forward-line dir)
   (back-to-indentation)
-  (cond ((< original-column (current-column))
-         (block-nav-move-block dir original-column))
-        ((string-empty-p (buffer-substring (line-beginning-position) (line-end-position)))
-         (block-nav-move-block dir original-column))
-        (t (when block-nav-center-after-scroll
-             (recenter)))))
+  (cond
+   ;; When line is empty, skip it
+   ((string-empty-p (buffer-substring (line-beginning-position) (line-end-position)))
+    (block-nav-move-block dir original-column))
+   ;; When line is shallower, skip it if enabled
+   ((> original-column (current-column))
+    (when block-nav-move-skip-shallower
+      (block-nav-move-block dir original-column)))
+   ;; When line is deeper, skip it
+   ((< original-column (current-column))
+    (block-nav-move-block dir original-column))
+   ;; Otherwise, stop at that line
+   (t
+    (when block-nav-center-after-scroll
+      (recenter)))))
 
 (defun block-nav-next-block ()
   "
@@ -84,10 +94,12 @@
   (interactive)
   (forward-line dir)
   (back-to-indentation)
-  (cond ((= original-column (current-column))
-         (block-nav-move-indentation-level dir original-column))
-        (t (when block-nav-center-after-scroll
-             (recenter))))) 
+  (cond
+   ((= original-column (current-column))
+    (block-nav-move-indentation-level dir original-column))
+   (t
+    (when block-nav-center-after-scroll
+      (recenter))))) 
   
 (defun block-nav-next-indentation-level ()
   "

--- a/block-nav.el
+++ b/block-nav.el
@@ -43,19 +43,24 @@
 
 (defvar block-nav-center-after-scroll nil
   "When not-nil, Emacs will recenter the current line after moving")
-(defvar block-nav-move-skip-shallower nil
+(defvar block-nav-move-skip-shallower t
   "
   When not-nil, calling `block-nav-next/previous-block` will 
   skip over lines with a shallower indentation than the current line.
   ")
 
 (defmacro do-while (cond &rest body)
+  "Runs the body once, then runs it again in a while loop with the condition."
   `(progn
      (progn . ,body)
      (while ,cond
        (progn . ,body))))
 
 (defun test-end-of-space (dir)
+  "
+  Returns true if the current line is either the first line in the file
+  or if the current line is the last line in the file or beyond the last line
+  "
   (or
    (and (> dir 0)
         (<= (count-lines (point-min) (point-max))
@@ -73,8 +78,8 @@
   (catch 'reached-end-of-file
    (let ((line-count 0))
      (do-while (or (if block-nav-move-skip-shallower
-                       (< original-column (current-column))
-                       (/= original-column (current-column)))
+                       (/= original-column (current-column))
+                       (< original-column (current-column)))
                    (string-empty-p (buffer-substring
                                     (line-beginning-position)
                                     (line-end-position))))


### PR DESCRIPTION
A couple things are happening in this PR:

- The recursive `block-nav-move-block` and `block-nav-move-indentation-level` are re-worked to be iterative using `do-while` loops instead of recursive.
- Instead of the `block-nav-move-block` and `block-nav-move-indentation-level` actually performing the moves, they simply return the number of lines to be moving so that it won't move at in certain cases. 
- Added the option to skip lines with a shallower indentation using `block-nav-move-block`